### PR TITLE
Add branch to compare command

### DIFF
--- a/gitgo.plugin.zsh
+++ b/gitgo.plugin.zsh
@@ -24,7 +24,8 @@ if [[ "$OSTYPE" = darwin* ]] || [[ "$OSTYPE" = linux* ]] ; then
 					finalurl=$(sed -e 's_:_/_' -e 's_git@_https://_' -e 's_\.git__' <<< "$url")
 				fi
 				if [[ $1 == "comp" ]]; then
-				 	$OPEN "$finalurl$PRPATH"
+					branch="$(git rev-parse --abbrev-ref HEAD)"
+				 	$OPEN "$finalurl$PRPATH/master...$branch"
 				elif [[ $1 == "pr" ]]; then
 					branch="$(git rev-parse --abbrev-ref HEAD)"
 					$OPEN "$finalurl$PRPATH/$branch?expand=1"


### PR DESCRIPTION
Suggestion for compare command.

Currently it opens the general compare page where one has to select the branch to compare.
Ex. `https://github.com/ltj/gitgo/compare`

I suggest that it should directly open a compare between master and current branch.
Ex. `https://github.com/ltj/gitgo/compare/master...new_branch`